### PR TITLE
Bootstrap assumes presence of curl on base box

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,6 +6,8 @@ if [ $? -ne 0 ]; then
     echo "$OPSCODE_REPO" | sudo tee -a $OPSCODE_SOURCE 
 fi
 
+sudo apt-get install curl -q -y
+
 sudo curl -s http://apt.opscode.com/packages@opscode.com.gpg.key | sudo apt-key add -
 sudo apt-get update
 echo "chef chef/chef_server_url string http://localhost:4000" >> chef.preseed


### PR DESCRIPTION
Replacing "precise_768MB_8GBx2" with the vagrantfiles "precise64" (which doesn't have curl installed) results in the chef installation failing with an error ("There are problems and -y was used without --force-yes").

This is because the public GPG key is missing and hence the signature verifications fail.

Suggested patch for bootstrap.sh is to [check the return code of `which curl` is 0, if not then] "sudo apt-get install curl -q -y" first.
