### PR TITLE
Enable multiple instances and override git repositories

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,6 +26,9 @@ local_config = {
   "zones" => Integer(ENV['ZONES'] || 4),
   "nodes" => Integer(ENV['NODES'] || 4),
   "disks" => Integer(ENV['DISKS'] || 4),
+  "swift_repo" => (ENV['SWIFT_REPO'] || 'git://github.com/openstack/swift.git'),
+  "swiftclient_repo" => (ENV['SWIFTCLIENT_REPO'] || 'git://github.com/openstack/python-swiftclient.git'),
+  "swift_bench_repo" => (ENV['SWIFTBENCH_REPO'] || 'git://github.com/openstack/swift-bench.git'),
 }
 
 

--- a/cookbooks/swift/recipes/source.rb
+++ b/cookbooks/swift/recipes/source.rb
@@ -2,21 +2,21 @@
 
 execute "git python-swiftclient" do
   cwd "/vagrant"
-  command "git clone git://github.com/openstack/python-swiftclient.git"
+  command "git clone #{node['swiftclient_repo']}"
   creates "/vagrant/python-swiftclient"
   action :run
 end
 
 execute "git swift-bench" do
   cwd "/vagrant"
-  command "git clone git://github.com/openstack/swift-bench.git"
+  command "git clone #{node['swift_bench_repo']}"
   creates "/vagrant/swift-bench"
   action :run
 end
 
 execute "git swift" do
   cwd "/vagrant"
-  command "git clone git://github.com/openstack/swift.git"
+  command "git clone #{node['swift_repo']}"
   creates "/vagrant/swift"
   action :run
 end

--- a/localrc-template
+++ b/localrc-template
@@ -11,3 +11,6 @@ export NODES=4
 export DISKS=4
 export STORAGE_POLICIES= # e.g. gold,silver
 export OBJECT_SYNC_METHOD=rsync  # or ssync
+export SWIFT_REPO=git://github.com/openstack/swift.git
+export SWIFTCLIENT_REPO=git://github.com/openstack/python-swiftclient.git
+export SWIFTBENCH_REPO=git://github.com/openstack/swift-bench.git


### PR DESCRIPTION
These changes fix the vagrant vm name uniqueness issue to allow more then one instance to be created per day.
The git repositories of swift, swiftclient and swift-bench can be overridden to allow using a fork and/or to specify a branch.
