### PR TITLE
Allow using tagged releases of Swift

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,9 +52,13 @@ local_config = {
   "nodes" => Integer(ENV['NODES'] || 4),
   "disks" => Integer(ENV['DISKS'] || 4),
   "swift_repo" => (ENV['SWIFT_REPO'] || 'git://github.com/openstack/swift.git'),
+  "swift_repo_branch" => (ENV['SWIFT_REPO_BRANCH'] || 'master'),
   "swiftclient_repo" => (ENV['SWIFTCLIENT_REPO'] || 'git://github.com/openstack/python-swiftclient.git'),
+  "swiftclient_repo_branch" => (ENV['SWIFTCLIENT_REPO_BRANCH'] || 'master'),
   "swift_bench_repo" => (ENV['SWIFTBENCH_REPO'] || 'git://github.com/openstack/swift-bench.git'),
+  "swift_bench_repo_branch" => (ENV['SWIFTBENCH_REPO_BRANCH'] || 'master'),
   "swift_specs_repo" => (ENV['SWIFTSPECS_REPO'] || 'git://github.com/openstack/swift-specs.git'),
+  "swift_specs_repo_branch" => (ENV['SWIFTSPECS_REPO_BRANCH'] || 'master'),
 }
 
 

--- a/cookbooks/swift/recipes/source.rb
+++ b/cookbooks/swift/recipes/source.rb
@@ -18,28 +18,28 @@
 
 execute "git python-swiftclient" do
   cwd "/vagrant"
-  command "git clone #{node['swiftclient_repo']}"
+  command "git clone -b #{node['swiftclient_repo_branch']} #{node['swiftclient_repo']}"
   creates "/vagrant/python-swiftclient"
   action :run
 end
 
 execute "git swift-bench" do
   cwd "/vagrant"
-  command "git clone #{node['swift_bench_repo']}"
+  command "git clone -b #{node['swift_bench_repo_branch']} #{node['swift_bench_repo']}"
   creates "/vagrant/swift-bench"
   action :run
 end
 
 execute "git swift" do
   cwd "/vagrant"
-  command "git clone #{node['swift_repo']}"
+  command "git clone -b #{node['swift_repo_branch']} #{node['swift_repo']}"
   creates "/vagrant/swift"
   action :run
 end
 
 execute "git swift-specs" do
   cwd "/vagrant"
-  command "git clone #{node['swift_specs_repo']}"
+  command "git clone -b #{node['swift_specs_repo_branch']} #{node['swift_specs_repo']}"
   creates "/vagrant/swift-specs"
   action :run
 end

--- a/localrc-template
+++ b/localrc-template
@@ -15,6 +15,7 @@ export EC_POLICY= # e.g. silver
 export OBJECT_SYNC_METHOD=rsync  # or ssync
 export POST_AS_COPY=true  # or false
 export SWIFT_REPO=git://github.com/openstack/swift.git
+export SWIFT_REPO_BRANCH=master
 export SWIFTCLIENT_REPO=git://github.com/openstack/python-swiftclient.git
 export SWIFTBENCH_REPO=git://github.com/openstack/swift-bench.git
 export SWIFTSPECS_REPO=git://github.com/openstack/swift-specs.git


### PR DESCRIPTION
Setting `SWIFT_REPO_BRANCH=2.2.2` in `localrc` allows someone to pin to a specific version.

While this may not be terribly helpful for developing Swift itself, it does let consumers developing applications against Swift work against the version they use in production. (This is our use case.)