### PR TITLE
Install pyeclib dependency

### DIFF
--- a/cookbooks/swift/recipes/source.rb
+++ b/cookbooks/swift/recipes/source.rb
@@ -64,7 +64,7 @@ end
 
 execute "python-swift-install" do
   cwd "/vagrant/swift"
-  command "python setup.py develop && pip install -r test-requirements.txt"
+  command "pip install -r requirements.txt && python setup.py develop && pip install -r test-requirements.txt"
   if not node['full_reprovision']
     creates "/usr/local/lib/python2.7/dist-packages/swift.egg-link"
   end


### PR DESCRIPTION
Fresh deployment failed using the latest Swift master branch due to a recently
introduced dependency on pyeclib>=1.0.3. This is not yet packaged on Ubuntu,
thus installing pyeclib using pip.