### PR TITLE
Fixing rebuildswift

### DIFF
--- a/bin/rebuildswift
+++ b/bin/rebuildswift
@@ -18,6 +18,6 @@
 rm -fr /etc/swift/*
 rm -f /etc/swift/*.builder /etc/swift/*.ring.gz \
   /etc/swift/backups/*.builder /etc/swift/backups/*.ring.gz
-cd /tmp/vagrant-chef/
+cd /tmp/vagrant-chef*/
 sed 's/"full_reprovision": false/"full_reprovision": true/g' dna.json > reload.json
 sudo chef-solo -c solo.rb -j reload.json

--- a/bin/rebuildswift
+++ b/bin/rebuildswift
@@ -18,6 +18,6 @@
 rm -fr /etc/swift/*
 rm -f /etc/swift/*.builder /etc/swift/*.ring.gz \
   /etc/swift/backups/*.builder /etc/swift/backups/*.ring.gz
-cd /tmp/vagrant-chef-*/
+cd /tmp/vagrant-chef/
 sed 's/"full_reprovision": false/"full_reprovision": true/g' dna.json > reload.json
 sudo chef-solo -c solo.rb -j reload.json

--- a/bin/reinstallswift
+++ b/bin/reinstallswift
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cd /tmp/vagrant-chef-*/
+cd /tmp/vagrant-chef*/
 sed 's/"full_reprovision": false/"full_reprovision": true/g' dna.json > reload.json
 sudo chef-solo -c solo.rb -j reload.json -o swift::source
 swift-init restart main

--- a/bin/remakerings
+++ b/bin/remakerings
@@ -17,4 +17,4 @@
 rm -f /etc/swift/*.builder /etc/swift/*.ring.gz \
   /etc/swift/backups/*.builder /etc/swift/backups/*.ring.gz
 
-cd /tmp/vagrant-chef-*/ && sudo chef-solo -c solo.rb -j dna.json -o swift::rings
+cd /tmp/vagrant-chef*/ && sudo chef-solo -c solo.rb -j dna.json -o swift::rings

--- a/bin/resetswift
+++ b/bin/resetswift
@@ -15,6 +15,6 @@
 # limitations under the License.
 
 /vagrant/bin/cleanswift
-cd /tmp/vagrant-chef-*/ && sudo chef-solo -c solo.rb -j dna.json -o swift::data
+cd /tmp/vagrant-chef*/ && sudo chef-solo -c solo.rb -j dna.json -o swift::data
 sudo service rsyslog restart
 sudo service memcached restart


### PR DESCRIPTION
The script was complaining about a missing dir under tmp. The pathing
just appeared to be incorrect. After making the minor change included
in this commit, the script ran successfully.