### PR TITLE
Update pip using pip after installing.

### DIFF
--- a/cookbooks/swift/recipes/setup.rb
+++ b/cookbooks/swift/recipes/setup.rb
@@ -55,6 +55,8 @@ extra_packages = node['extra_packages']
   end
 end
 
+execute "pip install -U pip"
+
 # setup environment
 
 execute "update-path" do


### PR DESCRIPTION
The stock pip seems to get corrupted during a fresh `vagrant up` at some
point in the chef run unless pip is updated first.