### PR TITLE
Remove pulling of unmerged encrypter/decrypter middleware changes from Gerrit

### DIFF
--- a/cookbooks/swift/files/default/etc/swift/proxy-server/proxy-server.conf.d/20_settings.conf
+++ b/cookbooks/swift/files/default/etc/swift/proxy-server/proxy-server.conf.d/20_settings.conf
@@ -2,7 +2,7 @@
 bind_port = 8080
 
 [pipeline:main]
-pipeline = catch_errors healthcheck proxy-logging cache container_sync bulk tempurl tempauth slo dlo decrypter trivialkeymaster encrypter fake_footers proxy-logging proxy-server
+pipeline = catch_errors healthcheck proxy-logging cache container_sync bulk tempurl tempauth slo dlo decrypter trivial_keymaster encrypter fake_footers proxy-logging proxy-server
 
 [filter:tempauth]
 use = egg:swift#tempauth

--- a/cookbooks/swift/recipes/source.rb
+++ b/cookbooks/swift/recipes/source.rb
@@ -37,13 +37,6 @@ execute "git swift" do
   action :run
 end
 
-# TODO: Grabbing feature/crypto changes that haven't been merged/pushed upstream.
-# This step should be REMOVED once the changes are merged to feature/crypto.
-execute "git swift crypto changes" do
-  cwd "/vagrant/swift"
-  command "git fetch https://review.openstack.org/openstack/swift refs/changes/38/214438/10 && git checkout FETCH_HEAD"
-end
-
 execute "git swift-specs" do
   cwd "/vagrant"
   command "git clone -b #{node['swift_specs_repo_branch']} #{node['swift_specs_repo']}"

--- a/cookbooks/swift/templates/default/etc/swift/proxy-server/default.conf-template.erb
+++ b/cookbooks/swift/templates/default/etc/swift/proxy-server/default.conf-template.erb
@@ -38,7 +38,7 @@ object_post_as_copy = <%= @post_as_copy %>
 [filter:decrypter]
 use = egg:swift#decrypter
 
-[filter:trivialkeymaster]
+[filter:trivial_keymaster]
 use = egg:swift#trivial_keymaster
 
 [filter:encrypter]


### PR DESCRIPTION
There is no need to pull the encrypter/decrypter middleware anymore from the Gerrit crypto branch as it was merged upstream:
https://review.openstack.org/#/c/194191/
https://github.com/openstack/swift/commit/f3231ff407bd731b054a42e2070be5768103fd18