### PR TITLE
move fkrull-deadsnakes PPA to trusty

### DIFF
--- a/cookbooks/swift/files/default/etc/apt/sources.list.d/fkrull-deadsnakes-precise.list
+++ b/cookbooks/swift/files/default/etc/apt/sources.list.d/fkrull-deadsnakes-precise.list
@@ -1,2 +1,0 @@
-deb http://ppa.launchpad.net/fkrull/deadsnakes/ubuntu precise main
-deb-src http://ppa.launchpad.net/fkrull/deadsnakes/ubuntu precise main

--- a/cookbooks/swift/files/default/etc/apt/sources.list.d/fkrull-deadsnakes-trusty.list
+++ b/cookbooks/swift/files/default/etc/apt/sources.list.d/fkrull-deadsnakes-trusty.list
@@ -1,0 +1,2 @@
+deb http://ppa.launchpad.net/fkrull/deadsnakes/ubuntu trusty main
+deb-src http://ppa.launchpad.net/fkrull/deadsnakes/ubuntu trusty main

--- a/cookbooks/swift/recipes/setup.rb
+++ b/cookbooks/swift/recipes/setup.rb
@@ -33,8 +33,8 @@ execute "deadsnakes key" do
   not_if "sudo apt-key list | grep 'Launchpad Old Python Versions'"
 end
 
-cookbook_file "/etc/apt/sources.list.d/fkrull-deadsnakes-precise.list" do
-  source "etc/apt/sources.list.d/fkrull-deadsnakes-precise.list"
+cookbook_file "/etc/apt/sources.list.d/fkrull-deadsnakes-trusty.list" do
+  source "etc/apt/sources.list.d/fkrull-deadsnakes-trusty.list"
   mode 0644
 end
 


### PR DESCRIPTION
the swift VM runs on trusty, trying to install python3.4 from fkrull-deadsnakes
for precise will result in file clashes. Specifically, libpython3.4-stdlib
3.4.3-2+precise1 and libpython3.4-minimal 3.4.3-1ubuntu1~14.04.3