### PR TITLE
introduce SOURCE_ROOT to clone git repositories into

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -63,6 +63,7 @@ local_config = {
   "swift_specs_repo" => (ENV['SWIFTSPECS_REPO'] || 'git://github.com/openstack/swift-specs.git'),
   "swift_specs_repo_branch" => (ENV['SWIFTSPECS_REPO_BRANCH'] || 'master'),
   "extra_key" => (ENV['EXTRA_KEY'] || ''),
+  "source_root" => (ENV['SOURCE_ROOT'] || '/vagrant'),
 }
 
 

--- a/cookbooks/swift/recipes/source.rb
+++ b/cookbooks/swift/recipes/source.rb
@@ -17,30 +17,30 @@
 # python install
 
 execute "git python-swiftclient" do
-  cwd "/vagrant"
+  cwd "#{node['source_root']}"
   command "git clone -b #{node['swiftclient_repo_branch']} #{node['swiftclient_repo']}"
-  creates "/vagrant/python-swiftclient"
+  creates "#{node['source_root']}/python-swiftclient"
   action :run
 end
 
 execute "git swift-bench" do
-  cwd "/vagrant"
+  cwd "#{node['source_root']}"
   command "git clone -b #{node['swift_bench_repo_branch']} #{node['swift_bench_repo']}"
-  creates "/vagrant/swift-bench"
+  creates "#{node['source_root']}/swift-bench"
   action :run
 end
 
 execute "git swift" do
-  cwd "/vagrant"
+  cwd "#{node['source_root']}"
   command "git clone -b #{node['swift_repo_branch']} #{node['swift_repo']}"
-  creates "/vagrant/swift"
+  creates "#{node['source_root']}/swift"
   action :run
 end
 
 execute "git swift-specs" do
-  cwd "/vagrant"
+  cwd "#{node['source_root']}"
   command "git clone -b #{node['swift_specs_repo_branch']} #{node['swift_specs_repo']}"
-  creates "/vagrant/swift-specs"
+  creates "#{node['source_root']}/swift-specs"
   action :run
 end
 
@@ -49,7 +49,7 @@ execute "fix semantic_version error from testtools" do
 end
 
 execute "python-swiftclient-install" do
-  cwd "/vagrant/python-swiftclient"
+  cwd "#{node['source_root']}/python-swiftclient"
   command "pip install -e . && pip install -r test-requirements.txt"
   if not node['full_reprovision']
     creates "/usr/local/lib/python2.7/dist-packages/python-swiftclient.egg-link"
@@ -58,7 +58,7 @@ execute "python-swiftclient-install" do
 end
 
 execute "swift-bench-install" do
-  cwd "/vagrant/swift-bench"
+  cwd "#{node['source_root']}/swift-bench"
   # swift-bench has an old version of hacking in the test requirements,
   # seems to pull back pbr to 0.11 and break everything; not installing
   # swift-bench's test-requirements is probably better than that
@@ -70,7 +70,7 @@ execute "swift-bench-install" do
 end
 
 execute "python-swift-install" do
-  cwd "/vagrant/swift"
+  cwd "#{node['source_root']}/swift"
   command "pip install -e . && pip install -r test-requirements.txt"
   if not node['full_reprovision']
     creates "/usr/local/lib/python2.7/dist-packages/swift.egg-link"
@@ -79,7 +79,7 @@ execute "python-swift-install" do
 end
 
 execute "swift-specs-install" do
-  cwd "/vagrant/swift-specs"
+  cwd "#{node['source_root']}/swift-specs"
   command "pip install -r requirements.txt"
   action :run
 end
@@ -97,7 +97,7 @@ end
   'python-swiftclient',
 ].each do |dirname|
   execute "ln #{dirname}" do
-    command "ln -s /vagrant/#{dirname} /home/vagrant/#{dirname}"
+    command "ln -s #{node['source_root']}/#{dirname} /home/vagrant/#{dirname}"
     creates "/home/vagrant/#{dirname}"
   end
 end

--- a/localrc-template
+++ b/localrc-template
@@ -27,3 +27,4 @@ export SWIFTBENCH_REPO=git://github.com/openstack/swift-bench.git
 export SWIFTSPECS_REPO=git://github.com/openstack/swift-specs.git
 export EXTRA_KEY=  # additional pubkey for ~vagrant/.ssh/authorized_keys
 export GUI=   # non-empty shows VirtualBox console window
+export SOURCE_ROOT=/vagrant # clone git repositories at this location


### PR DESCRIPTION
as experienced in
https://github.com/swiftstack/vagrant-swift-all-in-one/issues/28
virtualbox might not allow symlinks on /vagrant. Work around that by
introducing SOURCE_ROOT to be able to override git clone location.