### PR TITLE
Install liberasurecode packages

### DIFF
--- a/cookbooks/swift/recipes/setup.rb
+++ b/cookbooks/swift/recipes/setup.rb
@@ -58,7 +58,7 @@ required_packages = [
   "curl", "gcc", "memcached", "rsync", "sqlite3", "xfsprogs", "git-core",
   "build-essential", "python-dev", "libffi-dev", "python3.3", "python3.3-dev",
   "python3.4", "python3.4-dev", "python2.6", "python2.6-dev", "libxml2-dev",
-  "libxml2", "libxslt1-dev",
+  "libxml2", "libxslt1-dev", "liberasurecode-dev",
 ]
 extra_packages = node['extra_packages']
 (required_packages + extra_packages).each do |pkg|


### PR DESCRIPTION
I'm trying a `vagrant up` with latest master, but it fails with below error.
I fixed a swift recipes according to this patch(https://review.openstack.org/#/c/266618/1).

error:

```

==> default: Compiled Resource:
==> default: ------------------
==> default: # Declared in /tmp/vagrant-chef/9ecc7bdd633707cc6b292a93bb1c0305/cookbooks/swift/recipes/source.rb:80:in `from_file'
==> default: 

:

==> default: [2016-01-13T08:19:10+00:00] ERROR: execute[python-swift-install] (swift::source line 80) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '1'
==> default: ---- Begin output of pip install -e . && pip install -r test-requirements.txt ----
==> default: STDOUT: Obtaining file:///vagrant/swift

:

==> default: Building wheels for collected packages: xattr, PyECLib, dnspython, cffi, pycparser
==> default:   Running setup.py bdist_wheel for xattr
==> default:   Stored in directory: /root/.cache/pip/wheels/e9/e1/41/701f6479950ba53441d29e8dca07d49b91ae5af0b92cc02e05
==> default:   Running setup.py bdist_wheel for PyECLib
==> default:   Complete output from command /usr/bin/python -c "import setuptools;__file__='/tmp/pip-build-xqVxEX/PyECLib/setup.py';exec(compile(open(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" bdist_wheel -d /tmp/tmpOy48xSpip-wheel-:
==> default:   running bdist_wheel
==> default:   running build
==> default:   **************************************************************
==> default:   ***
==> default:   *** Can not locate liberasurecode.so.1
==> default:   ***
==> default:   *** Install -
==> default:   ***   Manual: https://bitbucket.org/tsg-/liberasurecode.git
==> default:   ***   Fedora/Red Hat variants: liberasurecode-devel
==> default:   ***   Debian/Ubuntu variants: liberasurecode-dev
==> default:   ***
==> default:   **************************************************************
==> default:   

```
