### PR TITLE
Adds liberasurecode-dev to the required packages

### DIFF
--- a/cookbooks/swift/recipes/setup.rb
+++ b/cookbooks/swift/recipes/setup.rb
@@ -43,7 +43,7 @@ end
 # packages
 # NOTE: Ubuntu Trusty 14.04 provides Python {2.7.6, 3.4.3} out of the box.
 required_packages = [
-  "libjerasure-dev",  # required for the EC biz
+  "libjerasure-dev", "liberasurecode-dev",  # required for the EC biz
   "libssl-dev", # libssl-dev is required for building wheels from the cryptography package in swift.
   "curl", "gcc", "memcached", "rsync", "sqlite3", "xfsprogs", "git-core",
   "build-essential", "libffi-dev", "python-dev",


### PR DESCRIPTION
Without this, the latest code in feature/crypto can't be built.
It seems to fail when building the wheels for PyECLib; get errors
about needing `liberasurecode.so.1` and a message to install
`liberasurecode-dev`.