### PR TITLE
support vagrant AWS provider

### DIFF
--- a/cookbooks/swift/recipes/setup.rb
+++ b/cookbooks/swift/recipes/setup.rb
@@ -18,6 +18,14 @@ execute "clean-up" do
   command "rm /home/vagrant/postinstall.sh || true"
 end
 
+execute 'create vagrant user' do
+  command 'sudo adduser --disabled-password --gecos "" vagrant || true'
+end
+
+execute 'ensure ssh directory exists' do
+  command 'mkdir -p ~vagrant/.ssh'
+end
+
 if node['extra_key'] then
   keys_file = "~vagrant/.ssh/authorized_keys"
   execute "add_extra_key" do


### PR DESCRIPTION
Hi,

We've just started using this to provision swift hosts for testing a backups tool. We've got it up and running on AWS, using an ubuntu base image and your existing chef cookbooks.

The only cookbook change we had to make was adding the vagrant user if it does not already exist, to support use of community AMIs that were not explicitly produced for use as a vagrant box (such as the official Canonical Ubuntu 14.04 image).

cc @mariantalla