### PR TITLE
Increase default RAM in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -92,7 +92,7 @@ Vagrant.configure("2") do |global_config|
 
         vb.name = "vagrant-#{hostname}-#{current_datetime}"
         vb.cpus = Integer(ENV['VAGRANT_CPUS'] || 1)
-        vb.memory = Integer(ENV['VAGRANT_RAM'] || 1024)
+        vb.memory = Integer(ENV['VAGRANT_RAM'] || 2048)
         if (ENV['GUI'] || '').nil?  # Why is my VM hung on boot? Find out!
           vb.gui = true
         end


### PR DESCRIPTION
Let's increase the default RAM in the Vagrantfile too, if one is not using a sourced localrc.