### PR TITLE
add autotest script

### DIFF
--- a/bin/autotest
+++ b/bin/autotest
@@ -1,0 +1,10 @@
+#!/bin/bash
+swift post autotest -r .r:*,.rlistings \
+    -m web-listings:true -m web-index:index.html
+.unittests --with-html-output --html-out-file /vagrant/swift/cover/result.html
+cd /vagrant/swift
+swift upload autotest cover/ > /dev/null
+swift upload autotest cover/result.html --object-name result/index.html > /dev/null
+echo 'DONE!'
+echo
+swift stat -v autotest | grep -i url


### PR DESCRIPTION
# PRO
- using static-web with listings is sort of a cute trick?
# CON
- don't love the name
- makes `au<tab>` not be `autodoc` anymore
- doesn't do any sort of "file watching" like `autodoc` does
