### PR TITLE
Haproxy

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,6 +61,7 @@ local_config = {
   "object_sync_method" => (ENV['OBJECT_SYNC_METHOD'] || 'rsync'),
   "post_as_copy" => (ENV['POST_AS_COPY'] || 'true').downcase == 'true',
   "encryption" => (ENV['ENCRYPTION'] || 'false').downcase == 'true',
+  "ssl" => (ENV['SSL'] || 'false').downcase == 'true',
   "part_power" => Integer(ENV['PART_POWER'] || 10),
   "replicas" => Integer(ENV['REPLICAS'] || 3),
   "ec_type" => (ENV['EC_TYPE'] || 'liberasurecode_rs_vand'),

--- a/cookbooks/swift/files/default/etc/haproxy/haproxy.cfg
+++ b/cookbooks/swift/files/default/etc/haproxy/haproxy.cfg
@@ -1,0 +1,42 @@
+global
+    log /dev/log	local0
+    log /dev/log	local1 notice
+    chroot /var/lib/haproxy
+    stats socket /run/haproxy/admin.sock mode 660 level admin
+    stats timeout 30s
+    user haproxy
+    group haproxy
+    daemon
+
+    # Default SSL material locations
+    ca-base /etc/ssl/certs
+    crt-base /etc/ssl/private
+
+    # Default ciphers to use on SSL-enabled listening sockets.
+    # For more information, see ciphers(1SSL). This list is from:
+    #  https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers/
+    ssl-default-bind-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS
+    ssl-default-bind-options no-sslv3
+
+    tune.ssl.default-dh-param 2048
+
+defaults
+    log	global
+    option	dontlognull
+    timeout connect 5000
+    timeout client  50000
+    timeout server  50000
+
+frontend www-http
+    bind *:80
+    reqadd X-Forwarded-Proto:\ http
+    default_backend www-backend
+
+frontend www-https
+    bind *:443 ssl crt /etc/ssl/private/saio.pem
+    reqadd X-Forwarded-Proto:\ https
+    default_backend www-backend
+
+backend www-backend
+    redirect scheme https if !{ ssl_fc }
+    server www-1 127.0.0.1:8080 send-proxy

--- a/cookbooks/swift/recipes/configs.rb
+++ b/cookbooks/swift/recipes/configs.rb
@@ -40,6 +40,34 @@ end
   end
 end
 
+# haproxy
+
+execute "create cert" do
+  command "openssl req -x509 -nodes -days 365 -newkey rsa:2048 " \
+    "-keyout saio.key -out saio.crt -subj '/CN=saio'"
+  cwd "/etc/ssl/private/"
+end
+
+execute "create pem" do
+  command "cat saio.crt saio.key > saio.pem"
+  cwd "/etc/ssl/private/"
+end
+
+cookbook_file "/etc/haproxy/haproxy.cfg" do
+  source "etc/haproxy/haproxy.cfg"
+  notifies :restart, 'service[haproxy]'
+  owner node['username']
+  group node['username']
+end
+
+service "haproxy" do
+  if node['ssl'] then
+    action :start
+  else
+    action :stop
+  end
+end
+
 # swift
 
 directory "/etc/swift" do
@@ -63,7 +91,6 @@ template "/etc/swift/swift.conf" do
 end
 
 [
-  'test.conf',
   'dispersion.conf',
   'bench.conf',
   'container-sync-realms.conf',
@@ -79,6 +106,13 @@ template "/etc/swift/base.conf-template" do
   source "etc/swift/base.conf-template.erb"
   variables({
     :username => node['username'],
+  })
+end
+
+template '/etc/swift/test.conf' do
+  source "etc/swift/test.conf.erb"
+  variables({
+    :ssl => node['ssl'],
   })
 end
 
@@ -119,11 +153,21 @@ end
     owner node["username"]
     group node["username"]
   end
-  cookbook_file "#{proxy_conf_dir}/20_settings.conf" do
-    source "#{proxy_conf_dir}/20_settings.conf"
-    owner node["username"]
-    group node["username"]
-  end
+end
+
+template "/etc/swift/proxy-server/proxy-server.conf.d/20_settings.conf" do
+  source "etc/swift/proxy-server/proxy-server.conf.d/20_settings.conf.erb"
+  owner node["username"]
+  group node["username"]
+  variables({
+    :ssl => node['ssl'],
+  })
+end
+
+cookbook_file "/etc/swift/proxy-server/proxy-noauth.conf.d/20_settings.conf" do
+  source "etc/swift/proxy-server/proxy-noauth.conf.d/20_settings.conf"
+  owner node["username"]
+  group node["username"]
 end
 
 ["object", "container", "account"].each_with_index do |service, p|

--- a/cookbooks/swift/recipes/setup.rb
+++ b/cookbooks/swift/recipes/setup.rb
@@ -61,7 +61,7 @@ required_packages = [
   "libssl-dev", # libssl-dev is required for building wheels from the cryptography package in swift.
   "curl", "gcc", "memcached", "rsync", "sqlite3", "xfsprogs", "git-core", "build-essential",
   "python-dev", "libffi-dev", "python3.5", "python3.5-dev",
-  "libxml2-dev", "libxml2", "libxslt1-dev", "autoconf", "libtool",
+  "libxml2-dev", "libxml2", "libxslt1-dev", "autoconf", "libtool", "haproxy",
 ]
 extra_packages = node['extra_packages']
 (required_packages + extra_packages).each do |pkg|
@@ -117,8 +117,14 @@ end
 
 # swift command line env setup
 
+if node['ssl'] then
+  auth_url = "https://#{node['hostname']}/auth/v1.0"
+else
+  auth_url = "http://#{node['hostname']}:8080/auth/v1.0"
+end
 {
-  "ST_AUTH" => "http://#{node['hostname']}:8080/auth/v1.0",
+  "ST_AUTH" => auth_url,
+  "SWIFTCLIENT_INSECURE" => "true",  # w/e it's *dev* ;)
   "ST_USER" => "test:tester",
   "ST_KEY" => "testing",
 }.each do |var, value|

--- a/cookbooks/swift/templates/default/etc/swift/proxy-server/proxy-server.conf.d/20_settings.conf.erb
+++ b/cookbooks/swift/templates/default/etc/swift/proxy-server/proxy-server.conf.d/20_settings.conf.erb
@@ -1,6 +1,9 @@
 [DEFAULT]
 bind_port = 8080
 
+[app:proxy-server]
+require_proxy_protocol = <%= @ssl %>
+
 [pipeline:main]
 pipeline = catch_errors healthcheck proxy-logging cache container_sync bulk tempurl tempauth staticweb slo dlo versioned_writes symlink keymaster encryption proxy-logging proxy-server
 
@@ -10,4 +13,4 @@ user_admin_admin = admin .admin .reseller_admin
 user_test_tester = testing .admin
 user_test2_tester2 = testing2 .admin
 user_test_tester3 = testing3
-
+storage_url_scheme = http<%= @ssl ? "s" : "" %>

--- a/cookbooks/swift/templates/default/etc/swift/test.conf.erb
+++ b/cookbooks/swift/templates/default/etc/swift/test.conf.erb
@@ -1,8 +1,9 @@
 [func_test]
 # sample config
-auth_host = 127.0.0.1
-auth_port = 8080
-auth_ssl = no
+auth_host = saio
+auth_port = <%= @ssl ? "443" : "8080" %>
+auth_ssl = <%= @ssl ? "yes" : "no" %>
+insecure = yes
 auth_prefix = /auth/
 
 # Primary functional test account (needs admin access to the account)

--- a/localrc-template
+++ b/localrc-template
@@ -25,6 +25,7 @@ export SERVERS_PER_PORT=0  # 1 port per dev in ring; N obj-servers per port
 export OBJECT_SYNC_METHOD=rsync  # or ssync
 export POST_AS_COPY=true  # or false
 export ENCRYPTION=false  # or true
+export SSL=false  # or true
 export SWIFT_REPO=git://github.com/openstack/swift.git
 export SWIFT_REPO_BRANCH=master
 export SWIFTCLIENT_REPO=git://github.com/openstack/python-swiftclient.git


### PR DESCRIPTION
This builds on the xenial branch because haproxy on trusty doesn't have ssl support

set `export SSL=true` in your localrc and destroy/up your new xenial box with haproxy forwarding requests to you 8080's

N.B. by default this configures haproxy to to use the PROXY protocol to talk to swift; so it needs the `require_proxy_protocol` patch [1]

If you don't care if you get a bunch of `127.0.0.1` in your logs like some sort of newb go ahead and fix the `haproxy.cfg`:

```
root@saio:/etc/haproxy# diff haproxy.cfg haproxy.cfg.no-proxy 
51c51
<    server www-1 127.0.0.1:8080 send-proxy

---
>    server www-1 127.0.0.1:8080
```
1. https://review.openstack.org/#/c/373563/
