### PR TITLE
vtox: don't create _setup.py

### DIFF
--- a/bin/vtox
+++ b/bin/vtox
@@ -21,7 +21,6 @@ cd /vagrant/swift
 sed -i "/envlist/ a\
 toxworkdir = $HOME/.tox-swift
 " tox.ini
-cp setup.py _setup.py
 set +e
 tox $ARGS
 error=$?


### PR DESCRIPTION
Commit 0421932 got rid of a bunch of setup.py hackery, but it missed
this line, so after running vtox you have this _setup.py file laying
around. It doesn't hurt anything, but it shows up as an untracked file
in `git status`.