### PR TITLE
Install Python 3.5, not 3.4, and not 2.6.

### DIFF
--- a/cookbooks/swift/recipes/setup.rb
+++ b/cookbooks/swift/recipes/setup.rb
@@ -60,7 +60,7 @@ end
 required_packages = [
   "libssl-dev", # libssl-dev is required for building wheels from the cryptography package in swift.
   "curl", "gcc", "memcached", "rsync", "sqlite3", "xfsprogs", "git-core", "build-essential",
-  "python-dev", "libffi-dev", "python3.4", "python3.4-dev", "python2.6", "python2.6-dev",
+  "python-dev", "libffi-dev", "python3.5", "python3.5-dev",
   "libxml2-dev", "libxml2", "libxslt1-dev", "autoconf", "libtool",
 ]
 extra_packages = node['extra_packages']


### PR DESCRIPTION
swiftclient and swift are both testing against 3.5 and not 3.4.

I also got rid of Python 2.6 since nothing's testing against that any more.