### PR TITLE
Use real mount points

### DIFF
--- a/bin/cleanswift
+++ b/bin/cleanswift
@@ -19,11 +19,13 @@ set -e
 swift-init all stop || :
 find /var/log/swift -type f -delete || :
 find /var/cache/swift* -type f -name *.recon -delete
-if mount | grep -q swift-disk ; then
-    sudo umount /mnt/swift-disk
-fi
+
+for d in $(ls -d /srv/node*/*); do
+    mount | grep -q $d && sudo umount $d
+done
 sudo rm -rf /srv/node*
-sudo rm -f /var/lib/swift/disk
+sudo rm -f /var/lib/swift/disk*
+
 for fname in /var/log/debug /var/log/messages /var/log/rsyncd.log /var/log/syslog; do
     sudo truncate --size 0 $fname
 done

--- a/cookbooks/swift/files/default/etc/swift/account-server/default.conf-template
+++ b/cookbooks/swift/files/default/etc/swift/account-server/default.conf-template
@@ -14,6 +14,7 @@ use = egg:swift#recon
 
 [account-replicator]
 # vm_test_mode = yes
+rsync_module = {replication_ip}::account{replication_port}
 
 [account-auditor]
 

--- a/cookbooks/swift/files/default/etc/swift/account-server/default.conf-template
+++ b/cookbooks/swift/files/default/etc/swift/account-server/default.conf-template
@@ -1,5 +1,4 @@
 [DEFAULT]
-mount_check = false
 disable_fallocate = true
 workers = 1
 

--- a/cookbooks/swift/files/default/etc/swift/container-server/default.conf-template
+++ b/cookbooks/swift/files/default/etc/swift/container-server/default.conf-template
@@ -14,6 +14,7 @@ use = egg:swift#recon
 
 [container-replicator]
 # vm_test_mode = yes
+rsync_module = {replication_ip}::container{replication_port}
 
 [container-updater]
 

--- a/cookbooks/swift/files/default/etc/swift/container-server/default.conf-template
+++ b/cookbooks/swift/files/default/etc/swift/container-server/default.conf-template
@@ -1,5 +1,4 @@
 [DEFAULT]
-mount_check = false
 disable_fallocate = true
 workers = 1
 

--- a/cookbooks/swift/recipes/setup.rb
+++ b/cookbooks/swift/recipes/setup.rb
@@ -158,7 +158,7 @@ end
 {
   "SOURCE_ROOT" => "#{node['source_root']}",
   "NOSE_INCLUDE_EXE" => "true",
-  "TMPDIR" => "/mnt/swift-disk/tmp",
+  "TMPDIR" => "/srv/node1/sdb1/tmp",
 }.each do |var, value|
   execute "swift-env-#{var}" do
     command "echo 'export #{var}=#{value}' >> #{profile_file}"

--- a/cookbooks/swift/templates/default/etc/rsyncd.conf.erb
+++ b/cookbooks/swift/templates/default/etc/rsyncd.conf.erb
@@ -4,20 +4,23 @@ log file = /var/log/rsyncd.log
 pid file = /var/run/rsyncd.pid
 address = 0.0.0.0
 
-[account]
-max connections = 25
-path = /mnt/swift-disk/
-read only = false
-lock file = /var/lock/account.lock
+<% (1..4).each do |i| -%>
 
-[container]
+[account60<%= i %>2]
 max connections = 25
-path = /mnt/swift-disk/
+path = /srv/node<%= i %>/
 read only = false
-lock file = /var/lock/container.lock
+lock file = /var/lock/account60<%= i %>2.lock
 
-[object]
+[container60<%= i %>1]
 max connections = 25
-path = /mnt/swift-disk/
+path = /srv/node<%= i %>/
 read only = false
-lock file = /var/lock/object.lock
+lock file = /var/lock/container60<%= i %>1.lock
+
+[object60<%= i %>0]
+max connections = 25
+path = /srv/node<%= i %>/
+read only = false
+lock file = /var/lock/object60<%= i %>0.lock
+<% end -%>

--- a/cookbooks/swift/templates/default/etc/swift/object-server/default.conf-template.erb
+++ b/cookbooks/swift/templates/default/etc/swift/object-server/default.conf-template.erb
@@ -1,5 +1,4 @@
 [DEFAULT]
-mount_check = false
 disable_fallocate = true
 workers = 1
 log_facility = LOG_LOCAL2

--- a/cookbooks/swift/templates/default/etc/swift/object-server/default.conf-template.erb
+++ b/cookbooks/swift/templates/default/etc/swift/object-server/default.conf-template.erb
@@ -22,5 +22,6 @@ use = egg:swift#recon
 [object-replicator]
 # vm_test_mode = yes
 sync_method = <%= @sync_method %>
+rsync_module = {replication_ip}::object{replication_port}
 
 [object-reconstructor]


### PR DESCRIPTION
Previously, we would create one loopback device with some subdirs to represent "drives" and symlink them into place under `/srv/node*`

Now, use N loopback devices. Note that you may want to crank down `LOOPBACK_GB` as it applies to each sparse file and the default may allow you to fill your VM's root disk. (Not immediately -- the files are still sparse -- but PUT enough data and you'll fill up.)

Two side benefits (beyond getting closer to "real" system behavior):
- we can now enable mount_check, and
- we can have per-node-and-service rsync modules.