### PR TITLE
Drop chef provisioning inputs into /etc/chef

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -134,6 +134,7 @@ Vagrant.configure("2") do |global_config|
       end
 
       config.vm.provision :chef_solo do |chef|
+        chef.provisioning_path = "/etc/chef"
         chef.add_recipe "swift"
         chef.json = local_config
       end

--- a/bin/rebuildswift
+++ b/bin/rebuildswift
@@ -16,7 +16,5 @@
 
 /vagrant/bin/cleanswift
 rm -fr /etc/swift/* /var/run/swift/* /var/cache/swift/* /etc/pykmip/*
-cd /tmp/vagrant-chef*/
-DIR=$(pwd)
-sed 's/"full_reprovision": false/"full_reprovision": true/g' dna.json > reload.json
-sudo chef-solo -c ${DIR}/solo.rb -j ${DIR}/reload.json
+sed 's/"full_reprovision": false/"full_reprovision": true/g' /etc/chef/dna.json > /tmp/reload.json
+sudo chef-solo -c /etc/chef/solo.rb -j /tmp/reload.json

--- a/bin/reinstallswift
+++ b/bin/reinstallswift
@@ -15,9 +15,7 @@
 # limitations under the License.
 
 set -e
-cd /tmp/vagrant-chef*/
-DIR=$(pwd)
-sed 's/"full_reprovision": false/"full_reprovision": true/g' dna.json > reload.json
-sudo chef-solo -c ${DIR}/solo.rb -j ${DIR}/reload.json -o swift::source
+sed 's/"full_reprovision": false/"full_reprovision": true/g' /etc/chef/dna.json > /tmp/reload.json
+sudo chef-solo -c /etc/chef/solo.rb -j /tmp/reload.json -o swift::source
 swift-init restart main
 echo "READY!"

--- a/bin/remakerings
+++ b/bin/remakerings
@@ -17,6 +17,4 @@
 rm -f /etc/swift/*.builder /etc/swift/*.ring.gz \
   /etc/swift/backups/*.builder /etc/swift/backups/*.ring.gz
 
-cd /tmp/vagrant-chef*/
-DIR=$(pwd)
-sudo chef-solo -c ${DIR}/solo.rb -j ${DIR}/dna.json -o swift::rings
+sudo chef-solo -c /etc/chef/solo.rb -j /etc/chef/dna.json -o swift::rings

--- a/bin/resetswift
+++ b/bin/resetswift
@@ -16,8 +16,6 @@
 
 set -e
 /vagrant/bin/cleanswift
-cd /tmp/vagrant-chef*/
-DIR=$(pwd)
-sudo chef-solo -c ${DIR}/solo.rb -j ${DIR}/dna.json -o swift::data
+sudo chef-solo -c /etc/chef/solo.rb -j /etc/chef/dna.json -o swift::data
 sudo service rsyslog restart
 sudo service memcached restart


### PR DESCRIPTION
...rather than /tmp/vagrant-chef-#

Now, `resetswift` will still work following a `vagrant reload`

Fixes #58.