### PR TITLE
Change zuul src_dir and add run.yaml step

### DIFF
--- a/cookbooks/swift/files/default/etc/ansible/hosts
+++ b/cookbooks/swift/files/default/etc/ansible/hosts
@@ -6,4 +6,4 @@ all:
     ansible_private_key_file: /vagrant/.vagrant/machines/default/virtualbox/private_key
     zuul:
       project:
-        src_dir: /vagrant/swift
+        src_dir: swift

--- a/cookbooks/swift/recipes/losf.rb
+++ b/cookbooks/swift/recipes/losf.rb
@@ -16,6 +16,7 @@
 [
   "common/install_losf_dependencies.yaml",
   "losf_setup/pre.yaml",
+  "losf_setup/run.yaml",
 ].each do |playbook|
   execute "ansible #{playbook}" do
     full_path = "/vagrant/swift/tools/playbooks/#{playbook}"


### PR DESCRIPTION
Maybe you'd rather have the index server start in a chef recipe ? (if we use the ansible run.yaml, as I did, it does start, but it also run the functests, which we may not want to do automatically in the SAIO case)