### PR TITLE
start collecting .function.sh

### DIFF
--- a/.functions.sh
+++ b/.functions.sh
@@ -1,0 +1,4 @@
+# collection of shell functions to maniuplate the active bash environment
+clear-auth() {
+  unset $( env | cut -d"=" -f 1 | egrep "^(OS|ST)_")
+}

--- a/cookbooks/swift/recipes/setup.rb
+++ b/cookbooks/swift/recipes/setup.rb
@@ -132,10 +132,13 @@ execute "update-path" do
   action :run
 end
 
-execute "add clear-auth function" do
-  command "echo 'clear-auth() { unset $( env | egrep \"^(OS|ST)_\" | sed -e \"s/=.*//\" ) ; }' >> #{profile_file}"
-  not_if "grep clear-auth #{profile_file}"
-  action :run
+[
+  "/vagrant/.functions.sh",
+].each do |filename|
+  execute "source-#{filename}" do
+    command "echo 'source #{filename}' >> #{profile_file}"
+    not_if "grep 'source #{filename}' #{profile_file}"
+  end
 end
 
 


### PR DESCRIPTION
I don't like echo'ing functions directly into .profile

it makes quoting annoying
testing updates requires re-running provision
update to the cod requires some tricky greps

I would prefer we don't really need bash functions, dropping small scripts in `vagrant/bin` makes them more obvious/discoverable and allows them to eventually "grow out" of bash  - but unfortunately bin scripts aren't a good fit when the goal is to manipulate the current bash environment

I'd like to get some feedback on if this is the right way to go