### PR TITLE
Add TLS support using haproxy

### DIFF
--- a/.s3cfg
+++ b/.s3cfg
@@ -1,6 +1,0 @@
-[default]
-access_key = test:tester
-host_base = saio:8080
-host_bucket = saio:8080
-secret_key = testing
-use_https = False

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,6 +61,7 @@ local_config = {
   "object_sync_method" => (ENV['OBJECT_SYNC_METHOD'] || 'rsync'),
   "use_python3" => (ENV['USE_PYTHON3'] || 'false').downcase == 'true',
   "encryption" => (ENV['ENCRYPTION'] || 'false').downcase == 'true',
+  "ssl" => (ENV['SSL'] || 'false').downcase == 'true',
   "kmip" => (ENV['KMIP'] || 'false').downcase == 'true',
   "zipkin" => (ENV['ZIPKIN'] || 'false').downcase == 'true',
   "part_power" => Integer(ENV['PART_POWER'] || 10),
@@ -145,7 +146,17 @@ Vagrant.configure("2") do |global_config|
         chef.custom_config_path = "chef.conf"
         chef.provisioning_path = "/etc/chef"
         chef.add_recipe "swift"
-        chef.json = local_config
+        chef.json = {
+          "ip" => ip,
+          "hostname" => hostname,
+        }
+        chef.json.merge! local_config
+        if chef.json['ssl'] then
+          chef.json['base_uri'] = "https://#{hostname}"
+        else
+          chef.json['base_uri'] = "http://#{hostname}:8080"
+        end
+        chef.json['auth_uri'] = "#{chef.json['base_uri']}/auth/v1.0"
       end
     end
   end

--- a/bin/rebuildswift
+++ b/bin/rebuildswift
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 /vagrant/bin/cleanswift
-rm -fr /etc/swift/* /var/run/swift/* /var/cache/swift/* /etc/pykmip/* /etc/rsyncd.*
+sudo rm -fr /etc/swift/* /var/run/swift/* /var/cache/swift/* /etc/pykmip/* \
+            /etc/rsyncd.* /etc/ssl/private/saio.* /etc/haproxy/haproxy.cfg
 sed 's/"full_reprovision": false/"full_reprovision": true/g' /etc/chef/dna.json > /tmp/reload.json
 sudo chef-solo -c /etc/chef/solo.rb -j /tmp/reload.json

--- a/cookbooks/swift/files/default/etc/haproxy/haproxy.cfg
+++ b/cookbooks/swift/files/default/etc/haproxy/haproxy.cfg
@@ -1,0 +1,43 @@
+global
+    log /dev/log    local0
+    log /dev/log    local1 notice
+    chroot /var/lib/haproxy
+    stats socket /run/haproxy/admin.sock mode 660 level admin
+    stats timeout 30s
+    user haproxy
+    group haproxy
+    daemon
+
+    # Default SSL material locations
+    ca-base /etc/ssl/certs
+    crt-base /etc/ssl/private
+
+    # Default ciphers to use on SSL-enabled listening sockets.
+    # For more information, see ciphers(1SSL). This list is from:
+    #  https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers/
+    # (as retrieved on 2020-01-04)
+    ssl-default-bind-options no-sslv3
+    ssl-default-bind-ciphers ECDH+AESGCM:ECDH+CHACHA20:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS:!AESCCM
+
+    ssl-default-server-options no-sslv3
+    ssl-default-server-ciphers ECDH+AESGCM:ECDH+CHACHA20:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS:!AESCCM
+
+    tune.ssl.default-dh-param 2048
+
+defaults
+    log global
+    option  dontlognull
+    timeout connect 5000
+    timeout client  50000
+    timeout server  50000
+
+frontend www-http
+    bind *:80
+    default_backend www-backend
+
+frontend www-https
+    bind *:443 ssl crt /etc/ssl/private/saio.pem
+    default_backend www-backend
+
+backend www-backend
+    server www-1 127.0.0.1:8080 send-proxy

--- a/cookbooks/swift/files/default/etc/swift/container-sync-realms.conf
+++ b/cookbooks/swift/files/default/etc/swift/container-sync-realms.conf
@@ -1,3 +1,0 @@
-[test]
-key = realm1key
-cluster_saio = http://saio:8080/v1/

--- a/cookbooks/swift/templates/default/etc/ssl/private/saio.conf.erb
+++ b/cookbooks/swift/templates/default/etc/ssl/private/saio.conf.erb
@@ -1,0 +1,24 @@
+[req]
+default_md = sha256
+prompt = no
+distinguished_name = subject
+x509_extensions = ext
+
+[subject]
+CN = <%= @hostname %>
+
+[ext]
+subjectKeyIdentifier    = hash
+authorityKeyIdentifier  = keyid:always, issuer:always
+basicConstraints        = CA:true
+subjectAltName          = @alt-names
+keyUsage                = digitalSignature, keyEncipherment, keyCertSign
+extendedKeyUsage        = serverAuth
+
+[alt-names]
+DNS.1   = <%= @hostname %>
+DNS.2   = *.<%= @hostname %>
+DNS.3   = <%= @ip %>.xip.io
+DNS.4   = *.<%= @ip %>.xip.io
+IP.1    = <%= @ip %>
+

--- a/cookbooks/swift/templates/default/etc/swift/container-sync-realms.conf.erb
+++ b/cookbooks/swift/templates/default/etc/swift/container-sync-realms.conf.erb
@@ -1,0 +1,3 @@
+[test]
+key = realm1key
+cluster_saio = <%= @auth_uri %>

--- a/cookbooks/swift/templates/default/etc/swift/dispersion.conf.erb
+++ b/cookbooks/swift/templates/default/etc/swift/dispersion.conf.erb
@@ -1,5 +1,5 @@
 [dispersion]
-auth_url = http://localhost:8080/auth/v1.0
+auth_url = <%= @auth_uri %>
 auth_user = test:tester
 auth_key = testing
 # auth_url = http://saio:5000/v2.0/

--- a/cookbooks/swift/templates/default/etc/swift/proxy-server/proxy-server.conf.d/20_settings.conf.erb
+++ b/cookbooks/swift/templates/default/etc/swift/proxy-server/proxy-server.conf.d/20_settings.conf.erb
@@ -4,6 +4,9 @@ bind_port = 8080
 [pipeline:main]
 pipeline = catch_errors healthcheck proxy-logging domain_remap cache container_sync bulk tempurl s3api tempauth <%= @zipkin %> staticweb slo dlo versioned_writes symlink <%= @keymaster_pipeline %> encryption proxy-logging proxy-server
 
+[app:proxy-server]
+require_proxy_protocol = <%= @ssl %>
+
 [filter:tempauth]
 use = egg:swift#tempauth
 user_admin_admin = admin .admin .reseller_admin

--- a/cookbooks/swift/templates/default/etc/swift/test.conf.erb
+++ b/cookbooks/swift/templates/default/etc/swift/test.conf.erb
@@ -1,9 +1,6 @@
 [func_test]
 # sample config
-auth_host = 127.0.0.1
-auth_port = 8080
-auth_ssl = no
-auth_prefix = /auth/
+auth_uri = <%= @auth_uri %>
 
 # Primary functional test account (needs admin access to the account)
 account = test
@@ -35,9 +32,10 @@ fake_syslog = False
 [probe_test]
 # check_server_timeout = 30
 validate_rsync = true
+proxy_base_url = <%= @base_uri %>
 
 [s3api_test]
-endpoint = http://saio:8080
+endpoint = <%= @base_uri %>
 access_key1 = test:tester
 secret_key1 = testing
 access_key2 = test:tester2

--- a/cookbooks/swift/templates/default/home/aws/config.erb
+++ b/cookbooks/swift/templates/default/home/aws/config.erb
@@ -7,7 +7,7 @@ aws_secret_access_key = testing
 # signature_version can be either s3v4 (for v4 sigs) or s3 (for v2)
 s3 =
 	signature_version = s3v4
-	endpoint_url = http://saio:8080
+	endpoint_url = <%= @base_uri %>
 s3api =
 	signature_version = s3v4
-	endpoint_url = http://saio:8080
+	endpoint_url = <%= @base_uri %>

--- a/cookbooks/swift/templates/default/home/s3cfg.erb
+++ b/cookbooks/swift/templates/default/home/s3cfg.erb
@@ -1,0 +1,6 @@
+[default]
+access_key = test:tester
+secret_key = testing
+host_base = <%= @ssl ? "saio" : "saio:8080" %>
+host_bucket = <%= @ssl ? "saio" : "saio:8080" %>
+use_https = <%= @ssl %>

--- a/localrc-template
+++ b/localrc-template
@@ -25,6 +25,7 @@ export SERVERS_PER_PORT=0  # 1 port per dev in ring; N obj-servers per port
 export CONTAINER_AUTO_SHARD=true  # or false
 export OBJECT_SYNC_METHOD=rsync  # or ssync
 export USE_PYTHON3=false  # or true
+export SSL=false  # or true
 export ENCRYPTION=false  # or true
 export KMIP=false  # or true
 export ZIPKIN=false  # or true


### PR DESCRIPTION
Have haproxy listen on both 443 and 80; client needs to be smart about whether it wants TLS or not.

Uses the PROXY protocol support introduced back in Swift 2.18.0; if you're testing an old version of Swift, you'll need to drop the `send-proxy` in `/etc/haproxy/haproxy.cfg`.

See also: #51