### PR TITLE
Remove OS_AUTH_TYPE env variable

### DIFF
--- a/cookbooks/swift/recipes/setup.rb
+++ b/cookbooks/swift/recipes/setup.rb
@@ -163,7 +163,6 @@ end
   "ST_AUTH" => node['auth_uri'],
   "ST_USER" => "test:tester",
   "ST_KEY" => "testing",
-  "OS_AUTH_TYPE" => "v1password",
   "OS_AUTH_URL" => "http://#{node['hostname']}:8080/auth/v1.0",
   "OS_USERNAME" => "test:tester",
   "OS_PASSWORD" => "testing",


### PR DESCRIPTION
Hello,

Since https://review.opendev.org/#/c/699457/, OS_AUTH_TYPE variable is read and rejected by python-swiftclient.
I suggest to remove it because I don't think is it currently used.

Edouard