### PR TITLE
Be able to configure replication network

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,6 +58,7 @@ local_config = {
   "storage_policies" => (ENV['STORAGE_POLICIES'] || 'default').split(','),
   "ec_policy" => (ENV['EC_POLICY'] || ''),
   "servers_per_port" => Integer(ENV['SERVERS_PER_PORT'] || 0),
+  "replication_servers" => (ENV['REPLICATION_SERVERS'] || 'false').downcase == 'true',
   "container_auto_shard" => (ENV['CONTAINER_AUTO_SHARD'] || 'true').downcase == 'true',
   "object_sync_method" => (ENV['OBJECT_SYNC_METHOD'] || 'rsync'),
   "use_python3" => (ENV['USE_PYTHON3'] || 'false').downcase == 'true',

--- a/cookbooks/swift/recipes/configs.rb
+++ b/cookbooks/swift/recipes/configs.rb
@@ -378,6 +378,7 @@ end
     else
       directory "/#{replication_conf_dir}" do
         action :delete
+        recursive true
       end
       link "/#{server_conf_dir}/40_replication.conf" do
         to "/#{service_dir}/replication-daemons.conf-template"

--- a/cookbooks/swift/templates/default/etc/swift/account-server/replication.conf-template.erb
+++ b/cookbooks/swift/templates/default/etc/swift/account-server/replication.conf-template.erb
@@ -1,0 +1,6 @@
+[account-replicator]
+rsync_module = {replication_ip}::account_{device}
+
+[account-auditor]
+
+[account-reaper]

--- a/cookbooks/swift/templates/default/etc/swift/account-server/server.conf-template.erb
+++ b/cookbooks/swift/templates/default/etc/swift/account-server/server.conf-template.erb
@@ -7,13 +7,7 @@ pipeline = <%= @zipkin %> recon account-server
 
 [app:account-server]
 use = egg:swift#account
+replication_server = <%= @replication_server %>
 
 [filter:recon]
 use = egg:swift#recon
-
-[account-replicator]
-rsync_module = {replication_ip}::account_{device}
-
-[account-auditor]
-
-[account-reaper]

--- a/cookbooks/swift/templates/default/etc/swift/account-server/settings.conf.erb
+++ b/cookbooks/swift/templates/default/etc/swift/account-server/settings.conf.erb
@@ -1,6 +1,3 @@
 [DEFAULT]
-devices = <%= @srv_path %>
-bind_ip = <%= @bind_ip %>
 bind_port = <%= @bind_port %>
 log_name = account-<%= @bind_port %>
-recon_cache_path = <%= @recon_cache_path %>

--- a/cookbooks/swift/templates/default/etc/swift/container-server/replication.conf-template.erb
+++ b/cookbooks/swift/templates/default/etc/swift/container-server/replication.conf-template.erb
@@ -1,16 +1,3 @@
-[DEFAULT]
-disable_fallocate = true
-workers = 1
-
-[pipeline:main]
-pipeline = <%= @zipkin %> recon container-server
-
-[app:container-server]
-use = egg:swift#container
-
-[filter:recon]
-use = egg:swift#recon
-
 [container-replicator]
 rsync_module = {replication_ip}::container_{device}
 

--- a/cookbooks/swift/templates/default/etc/swift/container-server/server.conf-template.erb
+++ b/cookbooks/swift/templates/default/etc/swift/container-server/server.conf-template.erb
@@ -1,0 +1,13 @@
+[DEFAULT]
+disable_fallocate = true
+workers = 1
+
+[pipeline:main]
+pipeline = <%= @zipkin %> recon container-server
+
+[app:container-server]
+use = egg:swift#container
+replication_server = <%= @replication_server %>
+
+[filter:recon]
+use = egg:swift#recon

--- a/cookbooks/swift/templates/default/etc/swift/container-server/settings.conf.erb
+++ b/cookbooks/swift/templates/default/etc/swift/container-server/settings.conf.erb
@@ -1,9 +1,8 @@
 [DEFAULT]
-devices = <%= @srv_path %>
-bind_ip = <%= @bind_ip %>
 bind_port = <%= @bind_port %>
 log_name = container-<%= @bind_port %>
-recon_cache_path = <%= @recon_cache_path %>
 
+<% if @include_replication_settings -%>
 [container-sharder]
 log_name = container-sharder-<%= @bind_port %>
+<% end -%>

--- a/cookbooks/swift/templates/default/etc/swift/node.conf-template.erb
+++ b/cookbooks/swift/templates/default/etc/swift/node.conf-template.erb
@@ -1,0 +1,4 @@
+[DEFAULT]
+devices = <%= @srv_path %>
+bind_ip = <%= @bind_ip %>
+recon_cache_path = <%= @recon_cache_path %>

--- a/cookbooks/swift/templates/default/etc/swift/object-server/replication.conf-template.erb
+++ b/cookbooks/swift/templates/default/etc/swift/object-server/replication.conf-template.erb
@@ -1,0 +1,9 @@
+[object-updater]
+
+[object-auditor]
+
+[object-replicator]
+sync_method = <%= @sync_method %>
+rsync_module = {replication_ip}::object_{device}
+
+[object-reconstructor]

--- a/cookbooks/swift/templates/default/etc/swift/object-server/server.conf-template.erb
+++ b/cookbooks/swift/templates/default/etc/swift/object-server/server.conf-template.erb
@@ -10,16 +10,7 @@ pipeline = <%= @zipkin %> recon object-server
 
 [app:object-server]
 use = egg:swift#object
+replication_server = <%= @replication_server %>
 
 [filter:recon]
 use = egg:swift#recon
-
-[object-updater]
-
-[object-auditor]
-
-[object-replicator]
-sync_method = <%= @sync_method %>
-rsync_module = {replication_ip}::object_{device}
-
-[object-reconstructor]

--- a/cookbooks/swift/templates/default/etc/swift/object-server/settings.conf.erb
+++ b/cookbooks/swift/templates/default/etc/swift/object-server/settings.conf.erb
@@ -1,6 +1,3 @@
 [DEFAULT]
-devices = <%= @srv_path %>
-bind_ip = <%= @bind_ip %>
 bind_port = <%= @bind_port %>
 log_name = object-<%= @bind_port %>
-recon_cache_path = <%= @recon_cache_path %>

--- a/localrc-template
+++ b/localrc-template
@@ -22,6 +22,7 @@ export EC_DISKS=8
 export STORAGE_POLICIES=default # e.g. gold,silver
 export EC_POLICY= # e.g. silver
 export SERVERS_PER_PORT=0  # 1 port per dev in ring; N obj-servers per port
+export REPLICATION_SERVERS=false  # or true
 export CONTAINER_AUTO_SHARD=true  # or false
 export OBJECT_SYNC_METHOD=rsync  # or ssync
 export USE_PYTHON3=false  # or true


### PR DESCRIPTION
Export `REPLICATION_SERVERS=true` to enable. When enabled:

 * [1-4].conf.d will *only* have configs for the data-network servers.
 * [5-8].conf.d will have the replication-network servers bound on ports 605x-608x, as well as configs for all background daemons.

Note that some upstream changes are required to get probe tests passing; at the very least,

 * account-reaper needs to be willing to look at replication_port to determine whether a device is local
 * container-sync needs to do the same
 * probe test brain probably needs to include replication servers when starting/stopping halves