### PR TITLE
Fix PyKMIP on focal

### DIFF
--- a/cookbooks/swift/templates/default/etc/pykmip/server.conf.erb
+++ b/cookbooks/swift/templates/default/etc/pykmip/server.conf.erb
@@ -4,7 +4,7 @@ port=5696
 certificate_path=<%= @server_crt %>
 key_path=<%= @server_key %>
 ca_path=<%= @ca_crt %>
-auth_suite=Basic
+auth_suite=TLS1.2
 policy_path=/etc/pykmip/policies
 database_path=/var/lib/pykmip/pykmip.db
 enable_tls_client_auth=False


### PR DESCRIPTION
I guess the client uses OS defaults, and those got more secure?

TLS1.2 seems to work fine on bionic, so I'm calling it good.