### PR TITLE
Add OTel tracing configuration to VSAIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,55 @@ These will expose /metrics endpoints on ports 9100-9105 which you can check dire
 
  * http://saio:9090/graph
 
+Request Tracing
+===============
+You can enable request tracing by:
+```
+export TRACING=true
+```
+
+When tracing has been enabled a Jaeger all-in-one will be started in the
+vagrant environment. It was started with the bin/reset_jaeger tool.  You can
+view all your traces at: http://saio:16686/search
+
+The reset_jaeger.sh script basically runs:
+
+```
+docker run -d --name jaeger \\
+-e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \\
+-p 5775:5775/udp \\
+-p 6831:6831/udp \\
+-p 6832:6832/udp \\
+-p 5778:5778 \\
+-p 16686:16686 \\
+-p 14268:14268 \\
+-p 14250:14250 \\
+-p 9411:9411 \\
+jaegertracing/all-in-one:1.27
+```
+
+See: https://www.jaegertracing.io/docs/1.27/getting-started/
+
+If you want to reset and clear the traces just run:
+```
+reset_jaeger.sh
+```
+
+NOTE: We should go via OTel collector, but I havn't implemented that yet. But there are some notes on that below
+
+For the OTel collector we should be able to run something like:
+```
+docker pull otel/opentelemetry-collector:latest
+docker run -d otel/opentelemetry-collector:latest
+```
+See: https://opentelemetry.io/docs/collector/getting-started/
+
+NOTE: of course you can also specify a version. We should probably pick whatever we use for prod (when we get that far)
+
+If you want to have a custom config, volume mount in a config:
+```
+docker run -v $(pwd)/config.yaml:/etc/otelcol/config.yaml otel/opentelemetry-collector
+```
 
 ninja-dev-tricks
 ================

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -70,6 +70,7 @@ local_config = {
   "source_root" => (ENV['SOURCE_ROOT'] || '/vagrant'),
   "extra_source" => (ENV['EXTRA_SOURCE'] || '/vagrant/.scratch'),
   "nvratelimit" => (ENV['NVRATELIMIT'] || 'false').downcase == 'true',
+  "tracing" => (ENV['TRACING'] || 'false').downcase == 'true',
 }
 
 

--- a/bin/reset_jaeger.sh
+++ b/bin/reset_jaeger.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+docker_id=$(docker ps |grep jaeger  |awk '{print $1}')
+
+if [ -n "$docker_id" ]; then
+  docker stop $docker_id
+  docker rm $docker_id
+fi
+
+docker run -d --name jaeger  -e COLLECTOR_ZIPKIN_HOST_PORT=:9411  \
+	-p 5775:5775/udp  -p 6831:6831/udp  -p 6832:6832/udp  -p 5778:5778  \
+	-p 16686:16686  -p 14268:14268  -p 14250:14250  -p 9411:9411  \
+	jaegertracing/all-in-one:1.27

--- a/cookbooks/swift/recipes/configs.rb
+++ b/cookbooks/swift/recipes/configs.rb
@@ -209,6 +209,7 @@ end
   'container-sync-realms.conf',
   'test.conf',
   'swift.conf',
+  'jaeger_exporter.json',
 ].each do |filename|
   template "/etc/swift/#{filename}" do
     source "/etc/swift/#{filename}.erb"
@@ -231,6 +232,7 @@ template "/etc/swift/proxy-server/default.conf-template" do
   group node["username"]
   variables({
     :disable_encryption => ! node['encryption'],
+    :tracing => node['tracing'],
   })
 end
 
@@ -268,6 +270,7 @@ end
       :keymaster_pipeline => keymaster_pipeline,
       :nvratelimit_pipeline => node['nvratelimit'] ? 'nvratelimit' : '',
       :statsd_exporter => node["statsd_exporter"],
+      :tracing => node['tracing'],
     })
   end
 end
@@ -301,6 +304,7 @@ end
     variables({
       :servers_per_port => node['servers_per_port'],
       :replication_server => !node["replication_servers"],
+      :tracing => node['tracing'],
     })
   end
   if node["replication_servers"] then
@@ -311,6 +315,7 @@ end
       variables({
         :servers_per_port => node['servers_per_port'],
         :replication_server => true,
+        :tracing => node['tracing'],
       })
     end
   else

--- a/cookbooks/swift/recipes/default.rb
+++ b/cookbooks/swift/recipes/default.rb
@@ -18,3 +18,7 @@ execute "startmain" do
   user node['username']
   group node["username"]
 end
+
+if node["tracing"] then
+  include_recipe "swift::tracing_info"
+end

--- a/cookbooks/swift/recipes/setup.rb
+++ b/cookbooks/swift/recipes/setup.rb
@@ -118,11 +118,21 @@ bash 'install pip' do
 end
 
 # install pip packages
-
-[
+pip_packages = [
   "s3cmd",
   "awscli-plugin-endpoint",
-].each do |pkg|
+]
+if node['tracing']
+  # Install OpenTelemetry tracing pip packages
+  pip_packages.concat [
+    "opentelemetry-api",
+    "opentelemetry-sdk",
+    "opentelemetry-semantic-conventions",
+    "opentelemetry-exporter-jaeger",
+  ]
+end
+
+pip_packages.each do |pkg|
   execute "pip install #{pkg}" do
     command "pip install #{pkg}"
   end

--- a/cookbooks/swift/recipes/tracing_info.rb
+++ b/cookbooks/swift/recipes/tracing_info.rb
@@ -1,0 +1,18 @@
+#
+#Copyright (c) 2015-2022, NVIDIA CORPORATION.
+#SPDX-License-Identifier: Apache-2.0
+
+execute "Start jaeger all-in-one docker image" do
+  command "/vagrant/bin/reset_jaeger.sh"
+end
+
+log 'show jaeger docker info' do
+  message %(
+  A Jaeger all-in-one has been started in the vagrant environment. It was started with the bin/reset_jaeger tool.
+  You can view all your traces at: http://saio:16686/search
+
+  If you want to reset and clear the traces just run:
+
+    reset_jaeger.sh
+  )
+end

--- a/cookbooks/swift/templates/default/etc/swift/account-server/server.conf-template.erb
+++ b/cookbooks/swift/templates/default/etc/swift/account-server/server.conf-template.erb
@@ -3,7 +3,7 @@ disable_fallocate = true
 workers = 1
 
 [pipeline:main]
-pipeline = recon account-server
+pipeline = <% if @tracing -%>trace <% end -%> recon account-server
 
 [app:account-server]
 use = egg:swift#account
@@ -13,3 +13,11 @@ replication_server = false
 
 [filter:recon]
 use = egg:swift#recon
+
+<% if @tracing -%>
+[filter:trace]
+use = egg:swift#trace
+trace_exporter_module = egg:swift#jaeger_exporter
+trace_exporter_config = /etc/swift/jaeger_exporter.json
+trace_name = Swift account-server
+<% end -%>

--- a/cookbooks/swift/templates/default/etc/swift/container-server/server.conf-template.erb
+++ b/cookbooks/swift/templates/default/etc/swift/container-server/server.conf-template.erb
@@ -3,7 +3,7 @@ disable_fallocate = true
 workers = 1
 
 [pipeline:main]
-pipeline = recon container-server
+pipeline = <% if @tracing -%>trace <% end -%> recon container-server
 
 [app:container-server]
 use = egg:swift#container
@@ -13,3 +13,11 @@ replication_server = false
 
 [filter:recon]
 use = egg:swift#recon
+
+<% if @tracing -%>
+[filter:trace]
+use = egg:swift#trace
+trace_exporter_module = egg:swift#jaeger_exporter
+trace_exporter_config = /etc/swift/jaeger_exporter.json
+trace_name = Swift container-server
+<% end -%>

--- a/cookbooks/swift/templates/default/etc/swift/jaeger_exporter.json.erb
+++ b/cookbooks/swift/templates/default/etc/swift/jaeger_exporter.json.erb
@@ -1,0 +1,5 @@
+{
+  "agent_host_name": "<%= @ip %>",
+  "agent_port": "6831",
+  "udp_split_oversized_batches": true
+}

--- a/cookbooks/swift/templates/default/etc/swift/object-server/server.conf-template.erb
+++ b/cookbooks/swift/templates/default/etc/swift/object-server/server.conf-template.erb
@@ -6,7 +6,7 @@ log_facility = LOG_LOCAL2
 servers_per_port = <%= @servers_per_port %>
 
 [pipeline:main]
-pipeline = recon object-server
+pipeline = <% if @tracing -%>trace <% end -%> recon object-server
 
 [app:object-server]
 use = egg:swift#object
@@ -16,3 +16,11 @@ replication_server = false
 
 [filter:recon]
 use = egg:swift#recon
+
+<% if @tracing -%>
+[filter:trace]
+use = egg:swift#trace
+trace_exporter_module = egg:swift#jaeger_exporter
+trace_exporter_config = /etc/swift/jaeger_exporter.json
+trace_name = Swift object-server
+<% end -%>

--- a/cookbooks/swift/templates/default/etc/swift/proxy-server/default.conf-template.erb
+++ b/cookbooks/swift/templates/default/etc/swift/proxy-server/default.conf-template.erb
@@ -90,3 +90,18 @@ use = egg:swift#ratelimit
 # container_listing_ratelimit_0 = 100
 # container_listing_ratelimit_10 = 50
 # container_listing_ratelimit_50 = 20
+
+<% if @tracing -%>
+[filter:trace]
+use = egg:swift#trace
+trace_exporter_module = egg:swift#jaeger_exporter
+trace_exporter_config = /etc/swift/jaeger_exporter.json
+trace_name = Swift proxy-server
+
+# The trace_key is the secret used when creating the trace_sig HMAC.
+trace_key = some_secret_key
+#
+# If you want to trace every n'th request then you can use the trace_every_x parameter. The default is 0
+# which is disabled.
+trace_every_x = 1
+<% end -%>

--- a/cookbooks/swift/templates/default/etc/swift/proxy-server/proxy-noauth.conf.d/20_settings.conf.erb
+++ b/cookbooks/swift/templates/default/etc/swift/proxy-server/proxy-noauth.conf.d/20_settings.conf.erb
@@ -6,7 +6,7 @@ log_statsd_port = 9125
 <% end -%>
 
 [pipeline:main]
-pipeline = catch_errors gatekeeper healthcheck proxy-logging cache list-endpoints bulk tempurl slo dlo versioned_writes symlink proxy-logging proxy-server
+pipeline = catch_errors gatekeeper healthcheck <% if @tracing -%>trace <% end -%> proxy-logging cache list-endpoints bulk tempurl slo dlo versioned_writes symlink proxy-logging proxy-server
 
 [filter:gatekeeper]
 use = egg:swift#gatekeeper

--- a/cookbooks/swift/templates/default/etc/swift/proxy-server/proxy-server.conf.d/20_settings.conf.erb
+++ b/cookbooks/swift/templates/default/etc/swift/proxy-server/proxy-server.conf.d/20_settings.conf.erb
@@ -6,7 +6,7 @@ log_statsd_port = 9120
 <% end -%>
 
 [pipeline:main]
-pipeline = catch_errors healthcheck proxy-logging domain_remap cache <%= @nvratelimit_pipeline %> etag-quoter container_sync bulk tempurl s3api tempauth ratelimit staticweb slo dlo versioned_writes symlink <%= @keymaster_pipeline %> encryption subrequest-logging proxy-server
+pipeline = catch_errors healthcheck <% if @tracing -%>trace <% end -%> proxy-logging domain_remap cache <%= @nvratelimit_pipeline %> etag-quoter container_sync bulk tempurl s3api tempauth ratelimit staticweb slo dlo versioned_writes symlink <%= @keymaster_pipeline %> encryption subrequest-logging proxy-server
 
 [app:proxy-server]
 require_proxy_protocol = <%= @ssl %>

--- a/localrc-template
+++ b/localrc-template
@@ -43,3 +43,4 @@ export GUI=   # non-empty shows VirtualBox console window
 export SOURCE_ROOT=/vagrant # clone git repositories at this location
 export EXTRA_SOURCE=/vagrant/.scratch
 export NVRATELIMIT=false # or true
+export TRACING=false # or true


### PR DESCRIPTION
When TRACING=true, the VSAIO will be configured to use tracing. This
involves:

 - Adding trace middleware to all the wsgi server pipelines and config
   (not internal client... but hmm)
 - Add bin/reset_jaeger.sh helper script to start and clear/restart the
 - Start a jaeger all-in-one in the virtual machine using reset_jaeger.sh
 - Add /etc/swift/jaeger_exporter.json file which points to the running docker
   image.
 - Sets up some basic configuration for the traces, namely trace every
   request going through the proxies.

Because the proxy spans can get quite big, they can get bigger then
opentracing UDP max size. So enable udp_split_oversize_batches in the
jaeger_exporter. Otherwise it's just dropped.

Also added a bunch tracing notes to the end of the chef run which
currently reads:

  ==> default: Recipe: swift::tracing_info
  ==> default:   * execute[Start jaeger all-in-one docker image] action run
  ==> default:
  ==> default:     [execute] Unable to find image 'jaegertracing/all-in-one:1.27' locally
  ==> default:               1.27: Pulling from jaegertracing/all-in-one
  ==> default:               a0d0a0d46f8b: Pulling fs layer
  ==> default:               b45576136ee2: Pulling fs layer
  ==> default:               d22e8500bf73: Pulling fs layer
  ==> default:               1a972b89c2b0: Pulling fs layer
  ==> default:               1a972b89c2b0: Waiting
  ==> default:               b45576136ee2: Verifying Checksum
  ==> default:               b45576136ee2: Download complete
  ==> default:               a0d0a0d46f8b: Verifying Checksum
  ==> default:               a0d0a0d46f8b: Download complete
  ==> default:               a0d0a0d46f8b: Pull complete
  ==> default:               b45576136ee2: Pull complete
  ==> default:               1a972b89c2b0: Verifying Checksum
  ==> default:               1a972b89c2b0: Download complete
  ==> default:               d22e8500bf73: Verifying Checksum
  ==> default:               d22e8500bf73: Download complete
  ==> default:               d22e8500bf73: Pull complete
  ==> default:               1a972b89c2b0: Pull complete
  ==> default:               Digest: sha256:8d0bff43db3ce5c528cb6f957520511d263d7cceee012696e4afdc9087919bb9
  ==> default:               Status: Downloaded newer image for jaegertracing/all-in-one:1.27
  ==> default:               59364e3d2e876234fc1b43d01ddd434d61dbc4bc1e659cd9bfb90d05aa13d15c
  ==> default: [2022-09-28T05:59:41+00:00] INFO: execute[Start jaeger all-in-one docker image] ran successfully
  ==> default:
  ==> default: - execute /vagrant/bin/reset_jaeger.sh
  ==> default:
  ==> default: * log[show jaeger docker info] action write
  ==> default: [2022-09-28T05:59:41+00:00] INFO:
  ==> default:   A Jaeger all-in-one has been started in the vagrant environment. It was started with the bin/reset_jaeger tool.
  ==> default:   You can view all your traces at: http://saio:16686/search
  ==> default:
  ==> default:   The reset_jaeger.sh script basically runs:
  ==> default:
  ==> default:     docker run -d --name jaeger \
  ==> default:     -e COLLECTOR_ZIPKIN_HOST_PORT=:9411 \
  ==> default:     -p 5775:5775/udp \
  ==> default:     -p 6831:6831/udp \
  ==> default:     -p 6832:6832/udp \
  ==> default:     -p 5778:5778 \
  ==> default:     -p 16686:16686 \
  ==> default:     -p 14268:14268 \
  ==> default:     -p 14250:14250 \
  ==> default:     -p 9411:9411 \
  ==> default:     jaegertracing/all-in-one:1.27
  ==> default:
  ==> default:   See: https://www.jaegertracing.io/docs/1.27/getting-started/
  ==> default:
  ==> default:   If you want to reset and clear the traces just run:
  ==> default:
  ==> default:     reset_jaeger.sh
  ==> default:
  ==> default:   NOTE: We should go via OTel collector, but I havn't implemented that yet. But there are some notes on that below
  ==> default:
  ==> default:   For the OTel collector we should be able to run something like:
  ==> default:
  ==> default:     docker pull otel/opentelemetry-collector:latest
  ==> default:     docker run -d otel/opentelemetry-collector:latest
  ==> default:
  ==> default:   See: https://opentelemetry.io/docs/collector/getting-started/
  ==> default:   NOTE: of course you can also specify a version. We should probably pick whatever we use for prod (when we get that far)
  ==> default:
  ==> default:   If you want to have a custom config, volume mount in a config:
  ==> default:
  ==> default:     docker run -v $(pwd)/config.yaml:/etc/otelcol/config.yaml otel/opentelemetry-collector