### PR TITLE
Pin sqlalchemy<2

### DIFF
--- a/cookbooks/swift/recipes/source.rb
+++ b/cookbooks/swift/recipes/source.rb
@@ -109,7 +109,7 @@ end
 
 execute "python-swift-install" do
   cwd "#{node['source_root']}/swift"
-  command "pip install -e .[kmip_keymaster] && pip install -r test-requirements.txt"
+  command "pip install 'sqlalchemy<2.0.0' -e .[kmip_keymaster] && pip install -r test-requirements.txt"
   if not node['full_reprovision']
     creates "/usr/local/lib/python2.7/dist-packages/swift.egg-link"
   end


### PR DESCRIPTION
Unfortunately, PyKMIP doesn't work with sqlalchemy 2.x yet. Complains like

`sqlalchemy.exc.InvalidRequestError: Implicitly combining column managed_objects.uid with column crypto_objects.uid under attribute 'unique_identifier'.  Please configure one or more attributes for these same-named columns explicitly.`