### PR TITLE
Add support for noble; drop support for precise, trusty, xenial

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,10 +9,7 @@ require 'ipaddr'
 
 DEFAULT_BOX = "jammy"
 
-# Note: 18.04/bionic requires Vagrant 2.02 or newer because 18.04 ships without ifup/ifdown by default.
 vagrant_boxes = {
-  "precise" => "https://hashicorp-files.hashicorp.com/precise64.box",
-  "xenial" => "http://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-vagrant.box",
   "bionic" => "http://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64-vagrant.box",
   "focal" => "http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64-vagrant.box",
   "focal-m1" => "https://app.vagrantup.com/luminositylabsllc/boxes/ubuntu-20.04-arm64/versions/20230901.220110.01/providers/parallels.box",
@@ -146,7 +143,7 @@ Vagrant.configure("2") do |global_config|
         v.tags = {'Name' => 'swift'}
       end
 
-      unless vagrant_box.start_with? 'jammy' then
+      if vagrant_box.start_with? 'focal' then
         # Install libssl for Chef (https://github.com/hashicorp/vagrant/issues/10914)
         config.vm.provision "shell",
           inline: "sudo apt-get update -y -qq && "\

--- a/localrc-template
+++ b/localrc-template
@@ -1,4 +1,4 @@
-export VAGRANT_BOX=jammy  # precise, xenial, bionic, etc.
+export VAGRANT_BOX=jammy  # or bionic, focal or bento/ubuntu-24.04
 # for libvirt, you need to use a libvirt box
 #export VAGRANT_BOX=jammy-libvirt
 #export LIBVIRT_DEFAULT_URI="qemu:///system"


### PR DESCRIPTION
Looks like deadsnakes only supports focal & jammy at the moment:

See https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa

Good news is, we can still test py2 on focal just fine. py36 testing maybe gets more difficult, though...