### PR TITLE
Enable account/container quotas by default

### DIFF
--- a/cookbooks/swift/templates/default/etc/swift/proxy-server/default.conf-template.erb
+++ b/cookbooks/swift/templates/default/etc/swift/proxy-server/default.conf-template.erb
@@ -25,6 +25,15 @@ enable_by_default = true
 [filter:bulk]
 use = egg:swift#bulk
 
+[filter:copy]
+use = egg:swift#copy
+
+[filter:container-quotas]
+use = egg:swift#container_quotas
+
+[filter:account-quotas]
+use = egg:swift#account_quotas
+
 [filter:slo]
 use = egg:swift#slo
 

--- a/cookbooks/swift/templates/default/etc/swift/proxy-server/proxy-server.conf.d/20_settings.conf.erb
+++ b/cookbooks/swift/templates/default/etc/swift/proxy-server/proxy-server.conf.d/20_settings.conf.erb
@@ -6,7 +6,7 @@ log_statsd_port = 9120
 <% end -%>
 
 [pipeline:main]
-pipeline = catch_errors healthcheck proxy-logging domain_remap cache <%= @nvratelimit_pipeline %> etag-quoter container_sync bulk tempurl s3api tempauth ratelimit staticweb slo dlo versioned_writes symlink <%= @keymaster_pipeline %> encryption subrequest-logging proxy-server
+pipeline = catch_errors healthcheck proxy-logging domain_remap cache <%= @nvratelimit_pipeline %> etag-quoter container_sync bulk tempurl s3api tempauth ratelimit staticweb copy container-quotas account-quotas slo dlo versioned_writes symlink <%= @keymaster_pipeline %> encryption subrequest-logging proxy-server
 
 [app:proxy-server]
 require_proxy_protocol = <%= @ssl %>

--- a/cookbooks/swift/templates/default/etc/swift/test.conf.erb
+++ b/cookbooks/swift/templates/default/etc/swift/test.conf.erb
@@ -22,6 +22,10 @@ password3 = testing3
 s3_access_key3 = test:tester3
 s3_secret_key3 = testing3
 
+account6 = admin
+username6 = admin
+password6 = admin
+
 collate = C
 
 storage_domain = saio


### PR DESCRIPTION
Also explicitly configure server-side copy, since the quota middlewares have opinions regarding placement.

Note that the `/etc/swift/test.conf` changes are mostly only useful for https://review.opendev.org/c/openstack/swift/+/928475 or later.