### PR TITLE
libvirt: give the private_network a name

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -115,7 +115,9 @@ Vagrant.configure("2") do |global_config|
 
       config.vm.provider "libvirt" do |lv, override|
         override.vm.hostname = hostname
-        override.vm.network :private_network, :ip => ip
+        override.vm.network :private_network,
+          :ip => ip,
+          :libvirt__network_name => 'saio'
         lv.cpus = Integer(ENV['VAGRANT_CPUS'] || 1)
         lv.memory = Integer(ENV['VAGRANT_RAM'] || 2048)
         lv.memorybacking :access, :mode => "shared"


### PR DESCRIPTION
When you create a vsaio in libvirt the name is automatically generated. But once created that name is written into vm xml. I run multiple and if I create another after a reboot a new private network is created if a create another one of my VSAIOs. If I then go back to my old one and fire it back up, it can't find the old private network anymore. You can run `virsh edit <vm>` and change the private network source network to fix it, but that's annoying.

Further I actually like that all my SAIO's are on the same private network. When you create a private_network in vagrant libvirt, you can actually specify the name. This way the same name will always be used.

This patch goes just that, and sets the name to `saio`. So when I fire up a bunch of vSAIOS it makes sure:

  1. They are all on the same network
  2. Even after libvirt has been restarted and you bring back older shutdown vms.