### PR TITLE
Add ring_version option to Vsaio

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -83,6 +83,7 @@ local_config = {
   "source_root" => (ENV['SOURCE_ROOT'] || '/vagrant'),
   "extra_source" => (ENV['EXTRA_SOURCE'] || '/vagrant/.scratch'),
   "nvratelimit" => (ENV['NVRATELIMIT'] || 'false').downcase == 'true',
+  "ring_version" => (ENV['RING_VERSION'] || '1'),
 }
 
 

--- a/cookbooks/swift/recipes/rings.rb
+++ b/cookbooks/swift/recipes/rings.rb
@@ -35,7 +35,7 @@
     end
   end
   execute "#{service}.builder-rebalance" do
-    command "swift-ring-builder /etc/swift/#{service}.builder rebalance -f"
+    command "swift-ring-builder /etc/swift/#{service}.builder rebalance -f --format-version=#{node['ring_version']}"
     user node['username']
     group node["username"]
     cwd "/etc/swift"
@@ -92,7 +92,7 @@ node['storage_policies'].each_with_index do |name, p|
     end
   end
   execute "#{service}.builder-rebalance" do
-    command "swift-ring-builder /etc/swift/#{service}.builder rebalance -f"
+    command "swift-ring-builder /etc/swift/#{service}.builder rebalance -f --format-version=#{node['ring_version']}"
     user node['username']
     group node["username"]
     cwd "/etc/swift"

--- a/localrc-template
+++ b/localrc-template
@@ -45,3 +45,4 @@ export GUI=   # non-empty shows VirtualBox console window
 export SOURCE_ROOT=/vagrant # clone git repositories at this location
 export EXTRA_SOURCE=/vagrant/.scratch
 export NVRATELIMIT=false # or true
+export RING_VERSION=1 # or 2


### PR DESCRIPTION
By default swift-ring-builder and remakerings will create rings in format_version/serialization version 1. But we want to have the ability to choose which version to run.

This patch adds a new option ring_version or in localrc RING_VERSION. This defaults to 1. But when set to 2 will build rings in v2.

It does this by simply adding --format-version=<ring_version> to the rings recipe which is called be remakerings in vSAIO.