### PR TITLE
stub some pipeline filters

### DIFF
--- a/cookbooks/swift/templates/default/etc/swift/proxy-server/default.conf-template.erb
+++ b/cookbooks/swift/templates/default/etc/swift/proxy-server/default.conf-template.erb
@@ -90,3 +90,18 @@ use = egg:swift#ratelimit
 # container_listing_ratelimit_0 = 100
 # container_listing_ratelimit_10 = 50
 # container_listing_ratelimit_50 = 20
+
+[filter:gatekeeper]
+use = egg:swift#gatekeeper
+
+[filter:listing_formats]
+use = egg:swift#listing_formats
+
+[filter:copy]
+use = egg:swift#copy
+
+[filter:container-quotas]
+use = egg:swift#container_quotas
+
+[filter:account-quotas]
+use = egg:swift#account_quotas


### PR DESCRIPTION
Some example pipelines explicitly insert gatekeeper and other upstream mw filters - it'd be more ergonomic to provide these filter names than not (even if we don't put them in the pipeline by default?)

This might also be considered one step closer to having these filters in the vsaio pipeline by default, apparently the gate testing of the saio uses a more extensive pipeline:

```
cgerrard@NVStation:~/Workspace/vagrant-swift-all-in-one$ grep "pipeline = " swift/doc/saio/swift/proxy-server.conf
pipeline = catch_errors gatekeeper healthcheck proxy-logging cache etag-quoter listing_formats bulk tempurl ratelimit crossdomain container_sync tempauth staticweb copy container-quotas account-quotas slo dlo versioned_writes symlink proxy-logging proxy-server
```