### PR TITLE
Allow setup without Deadsnakes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,6 +45,7 @@ end
 local_config = {
   "username" => username,
   "full_reprovision" => (ENV['FULL_REPROVISION'] || 'false').downcase == 'true',
+  "skip_deadsnakes" => (ENV['SKIP_DEADSNAKES'] || 'false').downcase == 'true',
   "loopback_gb" => Integer(ENV['LOOPBACK_GB'] || 4),
   "extra_packages" => (ENV['EXTRA_PACKAGES'] || '').split(','),
   "storage_policies" => (ENV['STORAGE_POLICIES'] || 'default,ec').split(','),

--- a/cookbooks/swift/recipes/setup.rb
+++ b/cookbooks/swift/recipes/setup.rb
@@ -30,20 +30,22 @@ if node['extra_key'] then
   end
 end
 
-# deadsnakes for all the pythons
-package "software-properties-common" do
-  action :install
-  not_if "which add-apt-repository"
-end
+unless node['skip_deadsnakes']
+  # deadsnakes for all the pythons
+  package "software-properties-common" do
+    action :install
+    not_if "which add-apt-repository"
+  end
 
-execute "deadsnakes key" do
-  command "sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys"
-  action :run
-  not_if "sudo apt-key list | grep 'Launchpad PPA for deadsnakes'"
-end
+  execute "deadsnakes key" do
+    command "sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys"
+    action :run
+    not_if "sudo apt-key list | grep 'Launchpad PPA for deadsnakes'"
+  end
 
-execute "add repo" do
-  command "sudo add-apt-repository ppa:deadsnakes/ppa"
+  execute "add repo" do
+    command "sudo add-apt-repository ppa:deadsnakes/ppa"
+  end
 end
 
 execute "apt-get-update" do
@@ -65,27 +67,28 @@ required_packages = [
   "curl", "gcc", "memcached", "rsync", "sqlite3", "xfsprogs", "git", "build-essential",
   "libffi-dev",  "libxml2-dev", "libxml2", "libxslt1-dev", "zlib1g-dev", "autoconf", "libtool",
   "haproxy", "docker-compose", "rclone",
-]
-
-# common python versions
-required_packages += [
-  # most of time these come from deadsnakes
-  "python3.7", "python3.7-distutils",
-  "python3.8", "python3.8-distutils",
-  "python3.9", "python3.9-distutils",
-  "python3.10",
-  "python3.11",
-  "python3.12",
-  "python3.13",  # edge of technology!
   # python3 will be redundant with distro version, -dev is needed for pyeclib
   "python3", "python3-dev",
 ]
 
-# only focal has the *really* old py3
-if node['platform_version'].to_i <= 20 then
+unless node['skip_deadsnakes']
+  # common python versions; most of these come from deadsnakes
   required_packages += [
-    "python3.6", "python3.6-distutils",
+    "python3.7", "python3.7-distutils",
+    "python3.8", "python3.8-distutils",
+    "python3.9", "python3.9-distutils",
+    "python3.10",
+    "python3.11",
+    "python3.12",
+    "python3.13",  # edge of technology!
   ]
+
+  # only focal has the *really* old py3
+  if node['platform_version'].to_i <= 20 then
+    required_packages += [
+      "python3.6", "python3.6-distutils",
+    ]
+  end
 end
 
 # no-no packages (PIP rules this vm, most system packages are all out-of-date anyway)

--- a/localrc-template
+++ b/localrc-template
@@ -24,6 +24,8 @@ export VAGRANT_HOSTNAME=saio
 export VAGRANT_CPUS=1
 export VAGRANT_RAM=2048
 export FULL_REPROVISION=false
+# Set true to use only the distro Python packages and skip the Deadsnakes PPA.
+export SKIP_DEADSNAKES=false
 export LOOPBACK_GB=4  # how much storage your swift has
 export IP=192.168.8.80
 export EXTRA_PACKAGES=ipython3,vim,screen,sysstat


### PR DESCRIPTION
Add SKIP_DEADSNAKES to retain distro Python and its development headers while bypassing the Deadsnakes PPA and version-specific packages.

The default behavior and the supported Focal Python 3.6 path remain unchanged.

Assisted-By: Codex:gpt-5.6