### PR TITLE
Skip disabled statsd exporter setup

### DIFF
--- a/cookbooks/swift/recipes/default.rb
+++ b/cookbooks/swift/recipes/default.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 include_recipe "swift::setup"
-include_recipe "swift::statsd_exporter"
+include_recipe "swift::statsd_exporter" if node["statsd_exporter"]
 include_recipe "swift::source"
 include_recipe "swift::data"
 include_recipe "swift::configs"


### PR DESCRIPTION
Include the StatsD exporter recipe only when that option is enabled.

When disabled, do not install StatsD Exporter or Prometheus.

Assisted-by: OpenAI Codex (GPT-5) <noreply@openai.com>